### PR TITLE
PR to fix iam role creation when log_destination_type is "s3"

### DIFF
--- a/.github/workflows/auto-badge.yaml
+++ b/.github/workflows/auto-badge.yaml
@@ -14,39 +14,15 @@ on:
       - 'releases/*'
       - 'chore/*'
       - 'chores/*'
+      - 'automation*'
 
 permissions: read-all
 
-env:
-  REPO_NAME: ${{ github.event.repository.name }}
-  REPO_OWNER: ${{ github.repository_owner }}
-
 jobs:
   auto-badge:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Git checkout Labs Tools
-      uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.AUTOMATION_TOKEN }}
-        repository: boldlink/labs-tools-scripts
-        ref: 'main'
-        path: .terraform_ignore
-
-    - name: Adding Workflow Badges
-      shell: bash
-      run: bash ${GITHUB_WORKSPACE}/.terraform_ignore/scripts/auto-badge/autobadge.sh && rm -rf ${GITHUB_WORKSPACE}/.terraform_ignore/
-
-    - name: Push changes automatically!
-      uses: EndBug/add-and-commit@v9
-      with:
-        message: '[Boldlinksig]: Workflow Badges Added/Updated.'
-        author_name: boldlinksig
-        author_email: boldlinksig@boldlink.io
-        committer_name: boldlinksig
-        committer_email: boldlinksig@boldlink.io
+    permissions:
+      contents: write
+    uses: boldlink/terraform-module-support/.github/workflows/auto-badge.yaml@main
+    secrets:
+      AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+      SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/.github/workflows/checkov.yaml
+++ b/.github/workflows/checkov.yaml
@@ -13,24 +13,14 @@ on:
       - 'releases/*'
       - 'chore/*'
       - 'chores/*'
+      - 'automation*'
+  schedule:
+    - cron: "00 18 * * *"
 
 permissions: read-all
 
 jobs:
-  scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.9
-      - name: Test terraform with Checkov
-        id: checkov
-        uses: bridgecrewio/checkov-action@v12
-        with:
-          file : tfplan.json
-          framework: all
-          output_format: sarif
-          download_external_modules: true
-          log_level: DEBUG
+  checkov-scan:
+    uses: boldlink/terraform-module-support/.github/workflows/checkov.yaml@main
+    secrets:
+      SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,16 +1,19 @@
 name: PR Labeler
 on:
   pull_request:
-    types: [opened]
+    types:
+      - opened
+      - reopened
 
 permissions: read-all
 
 jobs:
   pr-labeler:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: TimonVS/pr-labeler-action@v3
-        with:
-          configuration-path: .github/workflows/config/prl-config.yaml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: boldlink/terraform-module-support/.github/workflows/pr-labeler.yaml@main
+    with:
+      configuration-path: .github/workflows/config/prl-config.yaml
+    secrets:
+      SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,5 +1,4 @@
 name: pre-commit
-
 on:
   push:
 
@@ -14,66 +13,15 @@ on:
       - 'releases/*'
       - 'chore/*'
       - 'chores/*'
+      - 'automation*'
 
 permissions: read-all
 
-env:
-  TF_VER: "0.14.11"
-  TF_DOCS_VER: "v0.16.0"
-  TFLINT_VER: "v0.35.0"
-  BIN_PATH: "/home/runner/.local/bin"
-
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Install terraform binary #and extract only terraform-docs binary as extracting other files will override some module files
-      run: |
-        mkdir -p /home/runner/.local/bin
-        curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/${TF_DOCS_VER}/terraform-docs-${TF_DOCS_VER}-$(uname)-amd64.tar.gz
-        tar -zxvf terraform-docs.tar.gz terraform-docs
-        chmod +x terraform-docs
-        mv terraform-docs ${BIN_PATH}/terraform-docs
-
-    - name: Install TFLint binary
-      run: |
-        curl -sSLo tflint_linux_amd64.zip https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VER}/tflint_linux_amd64.zip
-        unzip tflint_linux_amd64.zip
-        chmod +x tflint
-        mv tflint ${BIN_PATH}/tflint
-
-    - name: Install Terraform binary
-      run: |
-        curl -sSLo terraform_${TF_VER}_linux_amd64.zip https://releases.hashicorp.com/terraform/${TF_VER}/terraform_${TF_VER}_linux_amd64.zip
-        unzip terraform_${TF_VER}_linux_amd64.zip
-        chmod +x terraform
-        mv terraform ${BIN_PATH}/terraform
-
-    - name: Enable python
-      uses: actions/setup-python@v3
-
-    - name: Install latest pre-commit
-      run: pip install --upgrade pre-commit
-
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date '+%d-%m-%Y %H:%M:%S')"
-
-    - name: Run pre-commit checks
-      run: while ! pre-commit run -a ; do pre-commit run -a ; done || exit 0
-
-    - name: Push changes automatically!
-      uses: EndBug/add-and-commit@v9
-      with:
-        message: '[Boldlinksig]: Pre-commit auto updated files on ${{ steps.date.outputs.date }}.'
-        fetch: true
-        pull: '--rebase --autostash'
-        author_name: boldlinksig
-        author_email: boldlinksig@boldlink.io
-        committer_name: boldlinksig
-        committer_email: boldlinksig@boldlink.io
+    permissions:
+      contents: write
+    uses: boldlink/terraform-module-support/.github/workflows/pre-commit.yaml@main
+    secrets:
+      AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+      SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,20 +1,17 @@
-name: Release
+name: update-files
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: "00 17 * * *"
 
 permissions: read-all
 
 jobs:
-  release:
+  update-files:
     permissions:
       contents: write
       pull-requests: write
-    uses: boldlink/terraform-module-support/.github/workflows/release.yaml@main
-    with:
-      config-name:  workflows/config/rd-config.yaml
+    uses: boldlink/terraform-module-support/.github/workflows/update.yaml@main
     secrets:
       AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
       SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - fix: count conditional for creating routes for NAT Gateway brings an error when no natgateway is specified, i.e neither "single" nor "multi" is specified. This in turn requires two deployments to remove unwanted Nat Gateway
 - fix: Remove `enable_private_subnets` variable from public subnets module and instead add a condition in private subnets module
-- fix: Don't create the iam role when `log_destination_type == "s3"
 - feat: Improve the documentation and examples for the subnets submodules (public; private; internal)
 - feat: Improve the documentation and examples for the endpoints sub module
 - feat: Improve the documentation and examples for the vpc-ipam sub module
@@ -21,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Remove the data source for the nat gw discovery and make it an option on the private module to remove dependencies
 - feat: Test and add to complete example ipv6 support
 - feat: Enable VPC endpoints and add examples
+
+## [3.0.3] - 2023-03-02
+### Description
+- fix: Don't create the iam role when `log_destination_type == "s3"
 
 ## [3.0.2] - 2022-12-27
 ### Description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stand alone VPC created only with default security
 
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-vpc/compare/3.0.2...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-vpc/compare/3.0.3...HEAD
 
+[3.0.3]: https://github.com/boldlink/terraform-aws-vpc/releases/tag/3.0.3
 [3.0.2]: https://github.com/boldlink/terraform-aws-vpc/releases/tag/3.0.2
 [3.0.1]: https://github.com/boldlink/terraform-aws-vpc/releases/tag/3.0.1
 [3.0.0]: https://github.com/boldlink/terraform-aws-vpc/releases/tag/3.0.0

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![License](https://img.shields.io/badge/License-Apache-blue.svg)](https://github.com/boldlink/terraform-aws-vpc/blob/main/LICENSE)
+[![Latest Release](https://img.shields.io/github/release/boldlink/terraform-aws-vpc.svg)](https://github.com/boldlink/terraform-aws-vpc/releases/latest)
+[![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/update.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/release.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ With releases `3.0.0` to `3.0.2` VPC Endpoints support has been removed and will
 ## Usage
 Examples available [`here`](./examples)
 
-*NOTE*: These examples use the latest version of this module
+**NOTE**: These examples use the latest version of this module
 
-```console
+```hcl
 module "minimum_vpc" {
-  source                 = "./../../"
+  source                 = "boldlink/vpc/aws"
   name                   = "minimum-vpc-example"
   cidr_block             = "172.16.0.0/16"
   enable_public_subnets  = true
@@ -74,13 +74,13 @@ module "minimum_vpc" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.57.0 |
 
 ## Modules
 
@@ -138,6 +138,7 @@ module "minimum_vpc" {
 | <a name="input_log_destination_type"></a> [log\_destination\_type](#input\_log\_destination\_type) | (Optional) The type of the logging destination. Valid values: `cloud-watch-logs`, `s3`. Default: `cloud-watch-logs`. | `string` | `"cloud-watch-logs"` | no |
 | <a name="input_log_format"></a> [log\_format](#input\_log\_format) | (Optional) The fields to include in the flow log record, in the order in which they should appear. | `string` | `null` | no |
 | <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | Use this variable to override the default log group name `/aws/vpc/name` | `string` | `null` | no |
+| <a name="input_logs_bucket_arn"></a> [logs\_bucket\_arn](#input\_logs\_bucket\_arn) | The ARN of the s3 bucket to store the logs. Provide this when the value of `log_destination_type` is `s3` | `string` | `null` | no |
 | <a name="input_logs_kms_key_id"></a> [logs\_kms\_key\_id](#input\_logs\_kms\_key\_id) | (Optional) The ARN of the KMS Key to use when encrypting log data. | `string` | `null` | no |
 | <a name="input_max_aggregation_interval"></a> [max\_aggregation\_interval](#input\_max\_aggregation\_interval) | (Optional) The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. Valid Values: `60 seconds (1 minute) or 600 seconds (10 minutes)`. Default: `600`. | `number` | `600` | no |
 | <a name="input_name"></a> [name](#input\_name) | Input the name of stack | `string` | n/a | yes |
@@ -149,8 +150,6 @@ module "minimum_vpc" {
 | <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | (Optional) Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire | `number` | `0` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level. | `map(string)` | `{}` | no |
 | <a name="input_traffic_type"></a> [traffic\_type](#input\_traffic\_type) | (Required) The type of traffic to capture. Valid values: `ACCEPT`,`REJECT`, `ALL`. | `string` | `"ALL"` | no |
-| <a name="input_vpc_assume_policy"></a> [vpc\_assume\_policy](#input\_vpc\_assume\_policy) | Override the default vpc flow log group assume role policy | `string` | `null` | no |
-| <a name="input_vpc_role_policy"></a> [vpc\_role\_policy](#input\_vpc\_role\_policy) | Override the default vpc flow log group role policy | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -15,13 +15,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.57.0 |
 
 ## Modules
 
@@ -37,7 +37,11 @@
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | The CIDR block of the vpc | `string` | `"10.1.0.0/16"` | no |
+| <a name="input_name"></a> [name](#input\_name) | The stack name | `string` | `"complete-vpc-example"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | The resource tags to be applied | `map(string)` | <pre>{<br>  "Department": "DevOps",<br>  "Environment": "example",<br>  "LayerId": "Example",<br>  "LayerName": "Example",<br>  "Owner": "Boldlink",<br>  "Project": "Examples",<br>  "user::CostCenter": "terraform-registry"<br>}</pre> | no |
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,3 +1,6 @@
+[![License](https://img.shields.io/badge/License-Apache-blue.svg)](https://github.com/boldlink/terraform-aws-vpc/blob/main/LICENSE)
+[![Latest Release](https://img.shields.io/github/release/boldlink/terraform-aws-vpc.svg)](https://github.com/boldlink/terraform-aws-vpc/releases/latest)
+[![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/update.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/release.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/examples/complete/locals.tf
+++ b/examples/complete/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  public1_subnets     = [cidrsubnet(var.cidr_block, 8, 1), cidrsubnet(var.cidr_block, 8, 2), cidrsubnet(var.cidr_block, 8, 3)]
+  eks_public_subnets  = [cidrsubnet(var.cidr_block, 8, 4), cidrsubnet(var.cidr_block, 8, 5), cidrsubnet(var.cidr_block, 8, 6)]
+  private1_subnets    = [cidrsubnet(var.cidr_block, 8, 7), cidrsubnet(var.cidr_block, 8, 8), cidrsubnet(var.cidr_block, 8, 9)]
+  eks_private_subnets = [cidrsubnet(var.cidr_block, 8, 10), cidrsubnet(var.cidr_block, 8, 11), cidrsubnet(var.cidr_block, 8, 12)]
+  database_subnets    = [cidrsubnet(var.cidr_block, 8, 13), cidrsubnet(var.cidr_block, 8, 14), cidrsubnet(var.cidr_block, 8, 15)]
+  redshift_subnets    = [cidrsubnet(var.cidr_block, 8, 16), cidrsubnet(var.cidr_block, 8, 17), cidrsubnet(var.cidr_block, 8, 18)]
+  override_azs        = ["${data.aws_region.current.id}a", "${data.aws_region.current.id}a", "${data.aws_region.current.id}a"]
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,25 +1,14 @@
-data "aws_region" "current" {}
-
-locals {
-  cidr_block          = "10.1.0.0/16"
-  public1_subnets     = [cidrsubnet(local.cidr_block, 8, 1), cidrsubnet(local.cidr_block, 8, 2), cidrsubnet(local.cidr_block, 8, 3)]
-  eks_public_subnets  = [cidrsubnet(local.cidr_block, 8, 4), cidrsubnet(local.cidr_block, 8, 5), cidrsubnet(local.cidr_block, 8, 6)]
-  private1_subnets    = [cidrsubnet(local.cidr_block, 8, 7), cidrsubnet(local.cidr_block, 8, 8), cidrsubnet(local.cidr_block, 8, 9)]
-  eks_private_subnets = [cidrsubnet(local.cidr_block, 8, 10), cidrsubnet(local.cidr_block, 8, 11), cidrsubnet(local.cidr_block, 8, 12)]
-  database_subnets    = [cidrsubnet(local.cidr_block, 8, 13), cidrsubnet(local.cidr_block, 8, 14), cidrsubnet(local.cidr_block, 8, 15)]
-  redshift_subnets    = [cidrsubnet(local.cidr_block, 8, 16), cidrsubnet(local.cidr_block, 8, 17), cidrsubnet(local.cidr_block, 8, 18)]
-  override_azs        = ["${data.aws_region.current.id}a", "${data.aws_region.current.id}a", "${data.aws_region.current.id}a"]
-}
-
 module "complete_vpc" {
   source                  = "./../../"
-  name                    = "complete-vpc-example"
-  cidr_block              = local.cidr_block
+  name                    = var.name
+  cidr_block              = var.cidr_block
   enable_dns_support      = true
   enable_dns_hostnames    = true
   enable_public_subnets   = true
   enable_private_subnets  = true
   enable_internal_subnets = true
+  tags                    = var.tags
+
   public_subnets = {
     public1 = {
       cidrs                   = local.public1_subnets
@@ -34,6 +23,7 @@ module "complete_vpc" {
       }
     }
   }
+
   private_subnets = {
     private1 = {
       cidrs = local.private1_subnets
@@ -46,6 +36,7 @@ module "complete_vpc" {
       }
     }
   }
+
   internal_subnets = {
     databases = {
       cidrs        = local.database_subnets
@@ -54,15 +45,5 @@ module "complete_vpc" {
     redshift = {
       cidrs = local.redshift_subnets
     }
-  }
-  tags = {
-    Environment        = "examples"
-    "user::CostCenter" = "terraform-registry"
-    department         = "operations"
-    InstanceScheduler  = true
-    Project            = "aws-vpc"
-    Owner              = "hugo.almeida"
-    LayerName          = "c300-aws-vpc"
-    LayerId            = "c300"
   }
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,1 +1,25 @@
-#(empty)
+variable "cidr_block" {
+  type        = string
+  description = "The CIDR block of the vpc"
+  default     = "10.1.0.0/16"
+}
+
+variable "name" {
+  type        = string
+  description = "The stack name"
+  default     = "complete-vpc-example"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "The resource tags to be applied"
+  default = {
+    Environment        = "example"
+    "user::CostCenter" = "terraform-registry"
+    Department         = "DevOps"
+    Project            = "Examples"
+    Owner              = "Boldlink"
+    LayerName          = "Example"
+    LayerId            = "Example"
+  }
+}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 4.50.0"
     }
   }
 }

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -1,3 +1,6 @@
+[![License](https://img.shields.io/badge/License-Apache-blue.svg)](https://github.com/boldlink/terraform-aws-vpc/blob/main/LICENSE)
+[![Latest Release](https://img.shields.io/github/release/boldlink/terraform-aws-vpc.svg)](https://github.com/boldlink/terraform-aws-vpc/releases/latest)
+[![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/update.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/release.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -15,7 +15,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.50.0 |
 
 ## Providers
 
@@ -33,7 +33,11 @@ No resources.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | The CIDR block of the vpc | `string` | `"10.1.0.0/16"` | no |
+| <a name="input_name"></a> [name](#input\_name) | The stack name | `string` | `"minimum-vpc-example"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | The resource tags to be applied | `map(string)` | <pre>{<br>  "Department": "DevOps",<br>  "Environment": "example",<br>  "LayerId": "Example",<br>  "LayerName": "Example",<br>  "Owner": "Boldlink",<br>  "Project": "Examples",<br>  "user::CostCenter": "terraform-registry"<br>}</pre> | no |
 
 ## Outputs
 

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -1,25 +1,18 @@
 locals {
-  cidr_block      = "10.1.0.0/16"
-  public1_subnets = [cidrsubnet(local.cidr_block, 8, 1), cidrsubnet(local.cidr_block, 8, 2), cidrsubnet(local.cidr_block, 8, 3)]
+  public_subnets = [cidrsubnet(var.cidr_block, 8, 1), cidrsubnet(var.cidr_block, 8, 2), cidrsubnet(var.cidr_block, 8, 3)]
 }
 
 module "minimum_vpc" {
   source                = "./../../"
-  name                  = "minimum-vpc-example"
-  cidr_block            = local.cidr_block
+  name                  = var.name
+  cidr_block            = var.cidr_block
   enable_public_subnets = true
+  tags                  = var.tags
+
   public_subnets = {
-    public1 = {
-      cidrs                   = local.public1_subnets
+    public = {
+      cidrs                   = local.public_subnets
       map_public_ip_on_launch = true
     }
-  }
-  tags = {
-    Environment        = "examples"
-    "user::CostCenter" = "terraform-registry"
-    department         = "operations"
-    InstanceScheduler  = true
-    LayerName          = "c300-aws-vpc"
-    LayerId            = "c300"
   }
 }

--- a/examples/minimum/variables.tf
+++ b/examples/minimum/variables.tf
@@ -1,1 +1,25 @@
-#(empty)
+variable "cidr_block" {
+  type        = string
+  description = "The CIDR block of the vpc"
+  default     = "10.1.0.0/16"
+}
+
+variable "name" {
+  type        = string
+  description = "The stack name"
+  default     = "minimum-vpc-example"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "The resource tags to be applied"
+  default = {
+    Environment        = "example"
+    "user::CostCenter" = "terraform-registry"
+    Department         = "DevOps"
+    Project            = "Examples"
+    Owner              = "Boldlink"
+    LayerName          = "Example"
+    LayerId            = "Example"
+  }
+}

--- a/examples/minimum/versions.tf
+++ b/examples/minimum/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 4.50.0"
     }
   }
 }

--- a/examples/single_nat/README.md
+++ b/examples/single_nat/README.md
@@ -1,3 +1,6 @@
+[![License](https://img.shields.io/badge/License-Apache-blue.svg)](https://github.com/boldlink/terraform-aws-vpc/blob/main/LICENSE)
+[![Latest Release](https://img.shields.io/github/release/boldlink/terraform-aws-vpc.svg)](https://github.com/boldlink/terraform-aws-vpc/releases/latest)
+[![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/update.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/release.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)

--- a/examples/single_nat/README.md
+++ b/examples/single_nat/README.md
@@ -14,7 +14,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.50.0 |
 
 ## Providers
 
@@ -32,7 +32,11 @@ No resources.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | The CIDR block of the vpc | `string` | `"10.1.0.0/16"` | no |
+| <a name="input_name"></a> [name](#input\_name) | The stack name | `string` | `"single-nat-vpc-example"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | The resource tags to be applied | `map(string)` | <pre>{<br>  "Department": "DevOps",<br>  "Environment": "example",<br>  "LayerId": "Example",<br>  "LayerName": "Example",<br>  "Owner": "Boldlink",<br>  "Project": "Examples",<br>  "user::CostCenter": "terraform-registry"<br>}</pre> | no |
 
 ## Outputs
 

--- a/examples/single_nat/locals.tf
+++ b/examples/single_nat/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  public_subnets  = [cidrsubnet(var.cidr_block, 8, 1), cidrsubnet(var.cidr_block, 8, 2), cidrsubnet(var.cidr_block, 8, 3)]
+  private_subnets = [cidrsubnet(var.cidr_block, 8, 4), cidrsubnet(var.cidr_block, 8, 5), cidrsubnet(var.cidr_block, 8, 6)]
+}

--- a/examples/single_nat/main.tf
+++ b/examples/single_nat/main.tf
@@ -1,36 +1,22 @@
-locals {
-  cidr_block       = "10.1.0.0/16"
-  public1_subnets  = [cidrsubnet(local.cidr_block, 8, 1), cidrsubnet(local.cidr_block, 8, 2), cidrsubnet(local.cidr_block, 8, 3)]
-  private1_subnets = [cidrsubnet(local.cidr_block, 8, 4), cidrsubnet(local.cidr_block, 8, 5), cidrsubnet(local.cidr_block, 8, 6)]
-}
-
 module "single_nat_vpc" {
   source                 = "./../../"
-  name                   = "single-nat-vpc-example"
-  cidr_block             = local.cidr_block
+  name                   = var.name
+  cidr_block             = var.cidr_block
   enable_public_subnets  = true
   enable_private_subnets = true
+  tags                   = var.tags
+
   public_subnets = {
-    public1 = {
-      cidrs                   = local.public1_subnets
+    public = {
+      cidrs                   = local.public_subnets
       map_public_ip_on_launch = true
       nat                     = "single"
     }
   }
-  private_subnets = {
-    private1 = {
-      cidrs = local.private1_subnets
-    }
-  }
 
-  tags = {
-    Environment        = "examples"
-    "user::CostCenter" = "terraform-registry"
-    department         = "operations"
-    InstanceScheduler  = true
-    Project            = "aws-vpc"
-    Owner              = "hugo.almeida"
-    LayerName          = "c300-aws-vpc"
-    LayerId            = "c300"
+  private_subnets = {
+    private = {
+      cidrs = local.private_subnets
+    }
   }
 }

--- a/examples/single_nat/variables.tf
+++ b/examples/single_nat/variables.tf
@@ -1,1 +1,25 @@
-#(empty)
+variable "cidr_block" {
+  type        = string
+  description = "The CIDR block of the vpc"
+  default     = "10.1.0.0/16"
+}
+
+variable "name" {
+  type        = string
+  description = "The stack name"
+  default     = "single-nat-vpc-example"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "The resource tags to be applied"
+  default = {
+    Environment        = "example"
+    "user::CostCenter" = "terraform-registry"
+    Department         = "DevOps"
+    Project            = "Examples"
+    Owner              = "Boldlink"
+    LayerName          = "Example"
+    LayerId            = "Example"
+  }
+}

--- a/examples/single_nat/versions.tf
+++ b/examples/single_nat/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 4.50.0"
     }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,12 +1,11 @@
 locals {
-  dns_suffix = data.aws_partition.current.dns_suffix
-  partition  = data.aws_partition.current.partition
-  account_id = data.aws_caller_identity.current.account_id
-  region     = data.aws_region.current.id
-  # logs_bucket_name  = var.logs_bucket_name == null ? "${var.name}-vpc-logs-${local.region}-${local.account_id}" : var.logs_bucket_name
+  dns_suffix        = data.aws_partition.current.dns_suffix
+  partition         = data.aws_partition.current.partition
+  account_id        = data.aws_caller_identity.current.account_id
+  region            = data.aws_region.current.id
   log_group_name    = var.log_group_name == null ? "/aws/vpc/${var.name}" : var.log_group_name
-  vpc_assume_policy = var.vpc_assume_policy == null ? data.aws_iam_policy_document.assume_policy.json : var.vpc_assume_policy
-  vpc_role_policy   = var.vpc_role_policy == null ? data.aws_iam_policy_document.role_policy.json : var.vpc_role_policy
+  vpc_assume_policy = data.aws_iam_policy_document.assume_policy.json
+  vpc_role_policy   = data.aws_iam_policy_document.role_policy.json
   # vpc_s3_role_policy   = var.vpc_s3_role_policy == null ? data.aws_iam_policy_document.s3_role_policy.json : var.vpc_s3_role_policy
   # vpc_s3_bucket_policy = var.vpc_s3_bucket_policy == null ? data.aws_iam_policy_document.s3_bucket_policy.json : var.vpc_s3_bucket_policy
   log_format = var.log_destination_type == "s3" ? var.log_format : null

--- a/modules/endpoints/README.md
+++ b/modules/endpoints/README.md
@@ -14,13 +14,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.57.0 |
 
 ## Modules
 

--- a/modules/endpoints/README.md
+++ b/modules/endpoints/README.md
@@ -1,3 +1,6 @@
+[![License](https://img.shields.io/badge/License-Apache-blue.svg)](https://github.com/boldlink/terraform-aws-vpc/blob/main/LICENSE)
+[![Latest Release](https://img.shields.io/github/release/boldlink/terraform-aws-vpc.svg)](https://github.com/boldlink/terraform-aws-vpc/releases/latest)
+[![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/update.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/release.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)

--- a/modules/endpoints/versions.tf
+++ b/modules/endpoints/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 4.50.0"
     }
   }
 }

--- a/modules/internal/README.md
+++ b/modules/internal/README.md
@@ -27,13 +27,13 @@ This module creates internal subnets.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.57.0 |
 
 ## Modules
 

--- a/modules/internal/README.md
+++ b/modules/internal/README.md
@@ -1,3 +1,6 @@
+[![License](https://img.shields.io/badge/License-Apache-blue.svg)](https://github.com/boldlink/terraform-aws-vpc/blob/main/LICENSE)
+[![Latest Release](https://img.shields.io/github/release/boldlink/terraform-aws-vpc.svg)](https://github.com/boldlink/terraform-aws-vpc/releases/latest)
+[![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/update.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/release.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)

--- a/modules/internal/versions.tf
+++ b/modules/internal/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 4.50.0"
     }
   }
 }

--- a/modules/private/README.md
+++ b/modules/private/README.md
@@ -27,13 +27,13 @@ This module creates private subnets.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.57.0 |
 
 ## Modules
 

--- a/modules/private/README.md
+++ b/modules/private/README.md
@@ -1,3 +1,6 @@
+[![License](https://img.shields.io/badge/License-Apache-blue.svg)](https://github.com/boldlink/terraform-aws-vpc/blob/main/LICENSE)
+[![Latest Release](https://img.shields.io/github/release/boldlink/terraform-aws-vpc.svg)](https://github.com/boldlink/terraform-aws-vpc/releases/latest)
+[![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/update.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/release.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)

--- a/modules/private/versions.tf
+++ b/modules/private/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 4.50.0"
     }
   }
 }

--- a/modules/public/README.md
+++ b/modules/public/README.md
@@ -1,3 +1,6 @@
+[![License](https://img.shields.io/badge/License-Apache-blue.svg)](https://github.com/boldlink/terraform-aws-vpc/blob/main/LICENSE)
+[![Latest Release](https://img.shields.io/github/release/boldlink/terraform-aws-vpc.svg)](https://github.com/boldlink/terraform-aws-vpc/releases/latest)
+[![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/update.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/release.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)

--- a/modules/public/README.md
+++ b/modules/public/README.md
@@ -27,13 +27,13 @@ This module creates public subnets.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.57.0 |
 
 ## Modules
 

--- a/modules/public/versions.tf
+++ b/modules/public/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 4.50.0"
     }
   }
 }

--- a/modules/vpc-ipam/README.md
+++ b/modules/vpc-ipam/README.md
@@ -14,13 +14,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.57.0 |
 
 ## Modules
 

--- a/modules/vpc-ipam/README.md
+++ b/modules/vpc-ipam/README.md
@@ -1,3 +1,6 @@
+[![License](https://img.shields.io/badge/License-Apache-blue.svg)](https://github.com/boldlink/terraform-aws-vpc/blob/main/LICENSE)
+[![Latest Release](https://img.shields.io/github/release/boldlink/terraform-aws-vpc.svg)](https://github.com/boldlink/terraform-aws-vpc/releases/latest)
+[![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/update.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/release.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)
 [![Build Status](https://github.com/boldlink/terraform-aws-vpc/actions/workflows/pr-labeler.yaml/badge.svg)](https://github.com/boldlink/terraform-aws-vpc/actions)

--- a/modules/vpc-ipam/versions.tf
+++ b/modules/vpc-ipam/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 4.50.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -216,20 +216,8 @@ variable "tags" {
   default     = {}
 }
 
-# variable "logs_bucket_name" {
-#   description = "The name of the s3 bucket to store the logs, use this variable of you want to override the default name `name-vpc-logs-region-account_id`"
-#   type        = string
-#   default     = null
-# }
-
-variable "vpc_assume_policy" {
-  description = "Override the default vpc flow log group assume role policy"
-  type        = string
-  default     = null
-}
-
-variable "vpc_role_policy" {
-  description = "Override the default vpc flow log group role policy"
+variable "logs_bucket_arn" {
+  description = "The ARN of the s3 bucket to store the logs. Provide this when the value of `log_destination_type` is `s3`"
   type        = string
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 4.50.0"
     }
   }
 }


### PR DESCRIPTION
# Description

This PR is created to fix the creation of iam role when only when the value of `var.log_destination_type` is `cloud-watch-logs`. Previously the IAM role was created even when the value of this variable was `s3`

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-vpc/blob/fix/logs-iam-role-fix/CHANGELOG.md#303---2023-03-02)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [ ] Have you updated the `README.md`(s)?
* [x] OWNER: Does your submission pass?
    * [x] Pre-commit (attach logs/print screen to this PR)
    * [x] Checkov/terrascan (attach logs/print screen to this PR)
    * [x] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] First PR? Have you deleted `## How to use this template...` from the root `.README.md`?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
